### PR TITLE
Make headers more include friendly

### DIFF
--- a/include/slimsig/connection.h
+++ b/include/slimsig/connection.h
@@ -12,7 +12,7 @@
 #include <functional>
 #include <algorithm>
 #include <limits>
-#include <slimsig/detail/slot.h>
+#include "detail/slot.h"
 
 namespace slimsig {
 template <class Signal>

--- a/include/slimsig/detail/signal_base.h
+++ b/include/slimsig/detail/signal_base.h
@@ -19,7 +19,8 @@
 #include <cmath>
 #include <cassert>
 
-#include <slimsig/connection.h>
+#include "../connection.h"
+
 namespace slimsig {
 
 template <class Handler>

--- a/include/slimsig/slimsig.h
+++ b/include/slimsig/slimsig.h
@@ -56,7 +56,7 @@
 #ifndef slimsignals_h
 #define slimsignals_h
 
-#include <slimsig/detail/signal_base.h>
+#include "detail/signal_base.h"
 
 namespace slimsig {
   template <class Handler, class SignalTraits = signal_traits<Handler>, class Allocator = std::allocator<std::function<Handler>>>


### PR DESCRIPTION
Currently, using this single-header library requires -I search path
setup. I believe it is nice to give users the choice to use this
without such a setup by including the slimsig.h header directly.

I don't think we loose anything by changing this. A system-wide slimsig
header should never be prefered over the local one when the local one
has been included directly.